### PR TITLE
Add http request headers as a top level object on websocket to make cook...

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -438,7 +438,9 @@ function OpenEvent(target) {
 function initAsServerClient(req, socket, upgradeHead, options) {
   options = new Options({
     protocolVersion: protocolVersion,
-    protocol: null
+    protocol: null,
+    deflate : false,
+    headers : {}
   }).merge(options);
 
   // expose state properties
@@ -446,6 +448,7 @@ function initAsServerClient(req, socket, upgradeHead, options) {
   this.protocolVersion = options.value.protocolVersion;
   this.supports.binary = (this.protocolVersion != 'hixie-76');
   this.supports.deflate = options.value.deflate;
+  this.headers = options.value.headers;
   this.upgradeReq = req;
   this.readyState = WebSocket.CONNECTING;
   this._isServer = true;

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -239,7 +239,8 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     var client = new WebSocket([req, socket, upgradeHead], {
       protocolVersion: version,
       protocol: protocol,
-      deflate: deflate || xdeflate
+      deflate: deflate || xdeflate,
+      headers: req.headers
     });
 
     if (self.options.clientTracking) {


### PR DESCRIPTION
...ie based auth easier.

[otf: 971 wl: 1 hrs]
