### PR TITLE
Preserve rsv1 bit on continuation frames.

### DIFF
--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -183,8 +183,8 @@ Receiver.prototype.processPacket = function (data) {
   }
   this.state.lastFragment = (data[0] & 0x80) == 0x80;
   this.state.masked = (data[1] & 0x80) == 0x80;
-  this.state.compressed = (data[0] & 0x40) == 0x40;
   var opcode = data[0] & 0xf;
+
   if (opcode === 0) {
     // continuation frame
     this.state.fragmentedOperation = true;
@@ -195,6 +195,7 @@ Receiver.prototype.processPacket = function (data) {
     }
   }
   else {
+    this.state.compressed = (data[0] & 0x40) == 0x40;
     if (opcode < 3 && this.state.activeFragmentedOperation != null) {
       this.error('data frames after the initial data frame must have opcode 0', 1002);
       return;
@@ -386,11 +387,11 @@ var opcodes = {
       var self = this;
       var tail = new Buffer(4);
       tail[0] = 0x0; tail[1] = 0x0; tail[2] = 0xff; tail[3] = 0xff;
+      data = this.unmask(mask, data, true);
       this.currentMessage.push(data);
       if (this.state.lastFragment) {
         var buf = this.concatBuffers(this.currentMessage);
         self.currentMessage = [];
-        buf = this.unmask(mask, buf, true);
         if(this.state.compressed) {
           var bc = Buffer.concat([buf, tail], buf.length + tail.length);
           var masked = self.state.masked;
@@ -400,7 +401,7 @@ var opcodes = {
               return;
             }
             if(err) {
-              self.error('invalid deflated buffer', 1007);
+              self.error('invalid deflated buffer ' + err, 1007);
               return;
             }
             if (!Validation.isValidUTF8(messageBuffer)) {


### PR DESCRIPTION
Unmask each frame individually.
Include zlib error message in error.
